### PR TITLE
 Add "addCallback" method for executing callbacks at the end of the

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,9 @@ var schema = new Schema()
   .addIndex('byFrequency', 'frequency')
 .version(4)
   .getStore('magazines')
-  .delIndex('byPublisher');
+  .delIndex('byPublisher').addCallback(function (upgradeNeededEvent) {
+    // Do something else
+  });
 
 // get schema version
 schema.version(); // 4
@@ -143,6 +145,11 @@ Options:
 ### schema.delIndex(name)
 
 Delete index by `name` from current store.
+
+### schema.addCallback(cb)
+
+Adds a callback to be executed at the end of the `upgradeneeded` event.
+Callback will be supplied the `upgradeneeded` event object.
 
 ### schema.clone()
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,6 +149,15 @@ Schema.prototype.delIndex = function(name) {
 }
 
 /**
+ * Add a callback to be executed at the end of the `upgradeneeded` event.
+ *  Callback will be supplied the `upgradeneeded` event object.
+ */
+Schema.prototype.addCallback = function(cb) {
+  this._versions[this.version()].callbacks.push(cb)
+  return this
+}
+
+/**
  * Generate onupgradeneeded callback.
  *
  * @return {Function}
@@ -229,12 +238,3 @@ Schema.prototype.clone = function() {
   })
   return schema
 }
-
-/**
- * Add a callback to be executed at the end of the `upgradeneeded` event.
- *  Callback will be supplied the `upgradeneeded` event object.
- */
- Schema.prototype.addCallback = function(cb) {
-   this._versions[this.version()].callbacks.push(cb)
-   return this
- }

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,7 +200,7 @@ Schema.prototype.callback = function() {
       })
 
       versionSchema.callbacks.forEach(function(i) {
-        i(e);
+        i(e)
       })
     })
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ Schema.prototype.version = function(version) {
     dropStores: [],  // db.deleteObjectStore
     indexes: [],     // store.createIndex
     dropIndexes: [], // store.deleteIndex
+    callbacks: [],
     version: version // version
   }
 
@@ -188,6 +189,10 @@ Schema.prototype.callback = function() {
         var store = tr.objectStore(i.storeName)
         store.deleteIndex(i.name)
       })
+
+      versionSchema.callbacks.forEach(function(i) {
+        i(e);
+      })
     })
   }
 }
@@ -224,3 +229,12 @@ Schema.prototype.clone = function() {
   })
   return schema
 }
+
+/**
+ * Add a callback to be executed at the end of the `upgradeneeded` event.
+ *  Callback will be supplied the `upgradeneeded` event object.
+ */
+ Schema.prototype.addCallback = function(cb) {
+   this._versions[this.version()].callbacks.push(cb)
+   return this
+ }


### PR DESCRIPTION
`upgradeneeded` event (Could not name as "callback" since that was already in use). Addresses treojs/treo/issues/36
